### PR TITLE
fix: delete day.js related

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,12 +12,6 @@ import views from './views';
 import zhCN from 'ant-design-vue/es/locale/zh_CN';
 import Container from '@/layouts/container.vue';
 
-import 'dayjs/locale/zh-cn';
-import dayjs from 'dayjs';
-
-dayjs.locale('zh-cn');
-
-
 onMounted(() => {
   vanillaTab.initDynamicViews(views);
 });


### PR DESCRIPTION
![1686737884916](https://github.com/xsbcme/vue3-vanilla-tab-demo/assets/69418751/d8626461-b61f-4aab-8136-698ff4f172b9)
![image](https://github.com/xsbcme/vue3-vanilla-tab-demo/assets/69418751/66688a3c-b368-496e-b84a-4f8858fc1b6e)
依赖里是没有day.js的，但是demo里使用了